### PR TITLE
Fixed dead link

### DIFF
--- a/petstoreRestApi.html
+++ b/petstoreRestApi.html
@@ -3,7 +3,7 @@
 <p style="font-size: 16px;">
     MireDot is a REST API documentation generator for Java. Below you can find the example documentation of our
     <a href="https://github.com/Qmino/miredot-petstore">Petstore</a> demo application.
-    <a href="http://miredot.com/instructions.html">Get started with MireDot now!</a> (it's free!)
+    <a href="http://www.miredot.com/docs/getting-started/">Get started with MireDot now!</a> (it's free!)
 </p>
 
 <p style="font-size: 16px;">


### PR DESCRIPTION
Set "Get started with MireDot now!" link in html intro to http://www.miredot.com/docs/getting-started/.